### PR TITLE
Remove slashes from artist and song names

### DIFF
--- a/yt2am.py
+++ b/yt2am.py
@@ -74,6 +74,7 @@ def cleanup_artist(text):
         n = m.group('artist')
     if ' x ' in n:
         return cleanup_artist(n)
+    n = n.replace('/', ' ').replace(',', '')
     return n
 
 
@@ -94,6 +95,8 @@ def cleanup_title(text):
     for p in TITLE_PATS:
         text = re.sub(p, r'\1', text)
 
+    text = text.replace('/', ' ').replace(',', '')
+    remix = remix.replace('/', ' ').replace(',', '')
     return f'{text} {remix}'.strip()
 
 


### PR DESCRIPTION
Slashes were breaking Shortcuts URL because they weren't quoted by `quote` call. This has been fixed.

Also, the commas are being removed from query URL as well since they can potentially harm search results